### PR TITLE
added bidirectional-ness to adding friend

### DIFF
--- a/app/api/bill_routes.py
+++ b/app/api/bill_routes.py
@@ -163,8 +163,8 @@ def editBill(billId):
 
                 diff = divvyed_expense - prev_initial_charge
 
-                friend1.balance -= diff
-                friend2.balance += diff
+                friend1.balance += diff
+                friend2.balance -= diff
 
                 friend_expense.amount_due += diff
 

--- a/app/api/friend_routes.py
+++ b/app/api/friend_routes.py
@@ -19,14 +19,20 @@ def add_friend():
     if form.validate_on_submit():
         friend_user = User.query.filter(User.username == form.data['username']).first()
 
-        new_friend = Friend(
+        new_friend1 = Friend(
             user_id=current_user.get_id(),
             friend_id=friend_user.id
         )
 
-        db.session.add(new_friend)
+        new_friend2 = Friend(
+            user_id=friend_user.id,
+            friend_id=current_user.get_id()
+        )
+
+        db.session.add(new_friend1)
+        db.session.add(new_friend2)
         db.session.commit()
-        return {"friend": new_friend.to_dict()}
+        return {"friend": new_friend1.to_dict()}
 
     return {'errors': validation_errors_to_error_messages(form.errors)}, 401
 

--- a/react-app/src/components/BillsTab/BillDetail.js
+++ b/react-app/src/components/BillsTab/BillDetail.js
@@ -8,7 +8,7 @@ const BillDetail = ({ bill }) => {
             <h3>Bill Detail</h3>
             <ul>
                 <li>
-                    OWNER ID: { bill.owner_id }
+                    OWNER: { bill.owner_name }
                 </li>
                 <li>
                     TOTAL AMOUNT: { bill.total_amount }


### PR DESCRIPTION
Was coming across a bug with editing a bill with a new friend because it couldn't find the friend balance to update - noticed adding a friend didn't create two rows in the Friends table. Fixed!